### PR TITLE
Add simple automation agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Truluke-
 Solutions for real world industries
+
+## Automation Agent
+
+`automation_agent.py` is a simple command line utility that executes system commands provided by the user. Run the script with Python and type your desired commands. Type `exit` or `quit` to end the session.

--- a/automation_agent.py
+++ b/automation_agent.py
@@ -1,0 +1,28 @@
+import subprocess
+import shlex
+
+
+def run_command(cmd: str):
+    """Run a system command and return the output."""
+    try:
+        result = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, check=True, text=True)
+        return result.stdout
+    except subprocess.CalledProcessError as exc:
+        return f"Command failed with return code {exc.returncode}:\n{exc.output}"
+
+
+def main():
+    print("Automation Agent - enter commands to run on your system. Type 'exit' to quit.")
+    while True:
+        command = input('> ').strip()
+        if command.lower() in {'exit', 'quit'}:
+            break
+        if not command:
+            continue
+        output = run_command(command)
+        print(output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `automation_agent.py` for running user-provided system commands
- document how to use the script in README

## Testing
- `python3 automation_agent.py <<EOF
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6854c0b6256c83248ed8ee2bff79f7e6